### PR TITLE
show full help with no arguments

### DIFF
--- a/archive-org-downloader.py
+++ b/archive-org-downloader.py
@@ -8,6 +8,7 @@ import img2pdf
 import time
 import argparse
 import os
+import sys
 import shutil
 
 
@@ -156,6 +157,9 @@ if __name__ == "__main__":
 	my_parser.add_argument('-r', '--resolution', help='Image resolution (10 to 0, 0 is the highest), [default 3]', type=int, default=3)
 	my_parser.add_argument('-t', '--threads', help="Maximum number of threads, [default 50]", type=int, default=50)
 	my_parser.add_argument('-j', '--jpg', help="Output to individual JPG's rather then a PDF", action='store_true')
+	if len(sys.argv) == 1:
+		my_parser.print_help(sys.stderr)
+		sys.exit(1)
 	args = my_parser.parse_args()
 
 	if args.url is None and args.file is None:


### PR DESCRIPTION
before

```
$ python archive-org-downloader.py 
usage: archive-org-downloader.py [-h] -e EMAIL -p PASSWORD [-u URL] [-f FILE] [-r RESOLUTION] [-t THREADS] [-j]
archive-org-downloader.py: error: the following arguments are required: -e/--email, -p/--password
```

after

```
$ python archive-org-downloader.py 
usage: archive-org-downloader.py [-h] -e EMAIL -p PASSWORD [-u URL] [-f FILE] [-r RESOLUTION] [-t THREADS] [-j]

optional arguments:
  -h, --help            show this help message and exit
  -e EMAIL, --email EMAIL
                        Your archive.org email
  -p PASSWORD, --password PASSWORD
                        Your archive.org password
  -u URL, --url URL     Link to the book (https://archive.org/details/XXXX). You can use this argument several times to download multiple books
  -f FILE, --file FILE  File where are stored the URLs of the books to download
  -r RESOLUTION, --resolution RESOLUTION
                        Image resolution (10 to 0, 0 is the highest), [default 3]
  -t THREADS, --threads THREADS
                        Maximum number of threads, [default 50]
  -j, --jpg             Output to individual JPG's rather then a PDF
```
