### PR TITLE
requirements: unpin img2pdf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 tqdm
-img2pdf==0.4.0
+img2pdf


### PR DESCRIPTION
... or why is [img2pdf](https://pypi.org/project/img2pdf/) pinned to 0.4.0?