### PR TITLE
use argparse's built in "arguments from file" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install -r requirements.txt
 ```
    
 ## Usage
-```sh
+```
 usage: archive-org-downloader.py [-h] -e EMAIL -p PASSWORD [-d DIR] [-r RESOLUTION] [-t THREADS] [-j] URL [URL ...]
 
 positional arguments:
@@ -74,7 +74,7 @@ python3 archive-org-downloader.py -e myemail@tempmail.com -p Passw0rd @books_to_
 ```
 
 You can also put your credentials (and any other arguments) in an `@file`:
-```sh
+```
 -e
 myemail@tempmail.com
 -p

--- a/README.md
+++ b/README.md
@@ -37,23 +37,26 @@ pip install -r requirements.txt
    
 ## Usage
 ```sh
-usage: archive-org-downloader.py [-h] -e EMAIL -p PASSWORD [-u URL] [-d DIR] [-f FILE] [-r RESOLUTION] [-t THREADS] [-j]
+usage: archive-org-downloader.py [-h] -e EMAIL -p PASSWORD [-d DIR] [-r RESOLUTION] [-t THREADS] [-j] URL [URL ...]
 
-optional arguments:
+positional arguments:
+  URL                   Link to the book (https://archive.org/details/XXXX).
+                        You can use this argument several times to download multiple books
+
+options:
   -h, --help            show this help message and exit
   -e EMAIL, --email EMAIL
                         Your archive.org email
   -p PASSWORD, --password PASSWORD
                         Your archive.org password
-  -u URL, --url URL     Link to the book (https://archive.org/details/XXXX). You can use this argument several times
-                        to download multiple books
   -d DIR, --dir DIR     Output directory
-  -f FILE, --file FILE  File where are stored the URLs of the books to download
   -r RESOLUTION, --resolution RESOLUTION
                         Image resolution (10 to 0, 0 is the highest), [default 3]
   -t THREADS, --threads THREADS
                         Maximum number of threads, [default 50]
-  -j, --jpg             Output to individual JPG's rather then a PDF
+  -j, --jpg             Output to individual JPG's rather than a PDF
+
+You can use @myfile to read arguments from the file myfile, one per line.
 ```
 The `email` and `password` fields are required, so to use this script you must have a registered account on archive.org.
 The `-r` argument specifies the resolution of the images (0 is the best quality).
@@ -62,13 +65,24 @@ The PDF are downloaded in the current folder
 ### Example
 This command will download the 3 books as pdf in the best possible quality. To only downlaod the individual images you can use `--jpg`.
 ```sh
-python3 archive-org-downloader.py -e myemail@tempmail.com -p Passw0rd -r 0 -u https://archive.org/details/IntermediatePython -u https://archive.org/details/horrorgamispooky0000bidd_m7r1 -u https://archive.org/details/elblabladelosge00gaut 
+python3 archive-org-downloader.py -e myemail@tempmail.com -p Passw0rd -r 0 https://archive.org/details/IntermediatePython https://archive.org/details/horrorgamispooky0000bidd_m7r1 https://archive.org/details/elblabladelosge00gaut
 ```
 
-If you want to download a lot of books in a raw you can paste the urls of the books in a .txt file (one per line) and use `--file`
+If you want to download a lot of books in a raw you can paste the urls of the books in a .txt file (one per line) and use `@file`
 ```sh
-python3 archive-org-downloader.py -e myemail@tempmail.com -p Passw0rd --file books_to_download.txt
+python3 archive-org-downloader.py -e myemail@tempmail.com -p Passw0rd @books_to_download.txt
 ```
+
+You can also put your credentials (and any other arguments) in an `@file`:
+```sh
+-e
+myemail@tempmail.com
+-p
+Passw0rd
+```
+
+Note: the previously required `-u` `--url` `-f` `--file` options have been removed.
+Now just put the URLs without `-u`, and use `@myfile` instead of `-f myfile`.
 
 ## Donation
 If you want to support my work, you can send 2 or 3 Bitcoins 🙃 to this address: 

--- a/archive-org-downloader.py
+++ b/archive-org-downloader.py
@@ -150,23 +150,22 @@ def make_pdf(pdf, title, directory):
 
 if __name__ == "__main__":
 
-	my_parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
+	my_parser = argparse.ArgumentParser(fromfile_prefix_chars='@', epilog='You can use @myfile to read arguments from the file myfile, one per line.')
 	my_parser.add_argument('-e', '--email', help='Your archive.org email', type=str, required=True)
 	my_parser.add_argument('-p', '--password', help='Your archive.org password', type=str, required=True)
-	my_parser.add_argument('-u', '--url', help='Link to the book (https://archive.org/details/XXXX). You can use this argument several times to download multiple books', action='append', type=str)
 	my_parser.add_argument('-d', '--dir', help='Output directory', type=str)
-	my_parser.add_argument('-f', '--file', help='File where are stored the URLs of the books to download', type=str)
 	my_parser.add_argument('-r', '--resolution', help='Image resolution (10 to 0, 0 is the highest), [default 3]', type=int, default=3)
 	my_parser.add_argument('-t', '--threads', help="Maximum number of threads, [default 50]", type=int, default=50)
 	my_parser.add_argument('-j', '--jpg', help="Output to individual JPG's rather than a PDF", action='store_true')
+	my_parser.add_argument('URL', help='Link to the book (https://archive.org/details/XXXX). You can use this argument several times to download multiple books', type=str, nargs='+')
 
 	if len(sys.argv) == 1:
 		my_parser.print_help(sys.stderr)
 		sys.exit(1)
 	args = my_parser.parse_args()
 
-	if args.url is None and args.file is None:
-		my_parser.error("At least one of --url and --file required")
+	if args.URL is None or len(args.URL) < 1:
+		my_parser.error("At least one url is required")
 
 	email = args.email
 	password = args.password
@@ -180,15 +179,7 @@ if __name__ == "__main__":
 		print(f"Output directory does not exist!")
 		exit()
 
-	if args.url is not None:
-		urls = args.url
-	else:
-		if os.path.exists(args.file):
-			with open(args.file) as f:
-				urls = f.read().strip().split("\n")
-		else:
-			print(f"{args.file} does not exist!")
-			exit()
+	urls = args.URL
 
 	# Check the urls format
 	for url in urls:

--- a/archive-org-downloader.py
+++ b/archive-org-downloader.py
@@ -150,7 +150,7 @@ def make_pdf(pdf, title, directory):
 
 if __name__ == "__main__":
 
-	my_parser = argparse.ArgumentParser()
+	my_parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
 	my_parser.add_argument('-e', '--email', help='Your archive.org email', type=str, required=True)
 	my_parser.add_argument('-p', '--password', help='Your archive.org password', type=str, required=True)
 	my_parser.add_argument('-u', '--url', help='Link to the book (https://archive.org/details/XXXX). You can use this argument several times to download multiple books', action='append', type=str)


### PR DESCRIPTION
The previously required `-u` `--url` `-f` `--file` options have been removed.
Now just put the URLs without `-u`, and use `@myfile` instead of `-f myfile`.

The `@file` support also allows keeping credentials and other favourite options in a file.