### PR TITLE
zero-pad page numbers

### DIFF
--- a/archive-org-downloader.py
+++ b/archive-org-downloader.py
@@ -97,18 +97,7 @@ def return_loan(session, book_id):
 		display_error(response, "Something went wrong when trying to return the book")
 
 def image_name(pages, page, directory):
-	if pages < 10:
-		return f"{directory}/{page:0>1}.jpg"
-	elif pages < 100:
-		return f"{directory}/{page:0>2}.jpg"
-	elif pages < 1000:
-		return f"{directory}/{page:0>3}.jpg"
-	elif pages < 10000:
-		return f"{directory}/{page:0>4}.jpg"
-	elif pages < 100000:
-		return f"{directory}/{page:0>5}.jpg"
-	else:
-		return f"{directory}/{page}.jpg"
+	return f"{directory}/{(len(str(pages)) - len(str(page))) * '0'}{page}.jpg"
 
 def download_one_image(session, link, i, directory, book_id, pages):
 	headers = {

--- a/archive-org-downloader.py
+++ b/archive-org-downloader.py
@@ -96,7 +96,21 @@ def return_loan(session, book_id):
 	else:
 		display_error(response, "Something went wrong when trying to return the book")
 
-def download_one_image(session, link, i, directory, book_id):
+def image_name(pages, page, directory):
+	if pages < 10:
+		return f"{directory}/{page:0>1}.jpg"
+	elif pages < 100:
+		return f"{directory}/{page:0>2}.jpg"
+	elif pages < 1000:
+		return f"{directory}/{page:0>3}.jpg"
+	elif pages < 10000:
+		return f"{directory}/{page:0>4}.jpg"
+	elif pages < 100000:
+		return f"{directory}/{page:0>5}.jpg"
+	else:
+		return f"{directory}/{page}.jpg"
+
+def download_one_image(session, link, i, directory, book_id, pages):
 	headers = {
 		"Referer": "https://archive.org/",
 		"Accept": "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
@@ -116,7 +130,7 @@ def download_one_image(session, link, i, directory, book_id):
 		except:
 			time.sleep(1)	# Wait 1 second before retrying
 
-	image = f"{directory}/{i}.jpg"
+	image = image_name(pages, i, directory)
 	with open(image,"wb") as f:
 		f.write(response.content)
 
@@ -124,16 +138,17 @@ def download_one_image(session, link, i, directory, book_id):
 def download(session, n_threads, directory, links, scale, book_id):	
 	print("Downloading pages...")
 	links = [f"{link}&rotate=0&scale={scale}" for link in links]
+	pages = len(links)
 
 	tasks = []
 	with futures.ThreadPoolExecutor(max_workers=n_threads) as executor:
 		for link in links:
 			i = links.index(link)
-			tasks.append(executor.submit(download_one_image, session=session, link=link, i=i, directory=directory ,book_id=book_id))
+			tasks.append(executor.submit(download_one_image, session=session, link=link, i=i, directory=directory, book_id=book_id, pages=pages))
 		for task in tqdm(futures.as_completed(tasks), total=len(tasks)):
 			pass
 	
-	images = [f"{directory}/{i}.jpg" for i in range(len(links))]
+	images = [image_name(pages, i, directory) for i in range(len(links))]
 	return images
 
 def make_pdf(pdf, title, directory):


### PR DESCRIPTION
for < 10 pages, 1 digit total
for < 100 pages, 2 digits total 00.jpg 01.jpg ... 09.jpg 10.jpg ... etc
etc for 1000, 10000, 100000 pages
for >= 100000 pages, no zero padding (as before)

this makes pages be listed in the correct order in more software, because with zero-padding lexical order equals numerical order.

Fixes: <https://github.com/MiniGlome/Archive.org-Downloader/issues/53>