### PR TITLE
support book ids as urls with prefix added automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ This command will download the 3 books as pdf in the best possible quality. To o
 python3 archive-org-downloader.py -e myemail@tempmail.com -p Passw0rd -r 0 -u https://archive.org/details/IntermediatePython -u https://archive.org/details/horrorgamispooky0000bidd_m7r1 -u https://archive.org/details/elblabladelosge00gaut 
 ```
 
+You can omit the `https://archive.org/details/` prefix and give book ids (without any `/`):
+```sh
+python3 archive-org-downloader.py -e myemail@tempmail.com -p Passw0rd -r 0 -u IntermediatePython -u horrorgamispooky0000bidd_m7r1 -u elblabladelosge00gaut
+```
+
 If you want to download a lot of books in a raw you can paste the urls of the books in a .txt file (one per line) and use `--file`
 ```sh
 python3 archive-org-downloader.py -e myemail@tempmail.com -p Passw0rd --file books_to_download.txt

--- a/archive-org-downloader.py
+++ b/archive-org-downloader.py
@@ -191,16 +191,23 @@ if __name__ == "__main__":
 			exit()
 
 	# Check the urls format
+	books = []
 	for url in urls:
-		if not url.startswith("https://archive.org/details/"):
-			print(f"{url} --> Invalid url. URL must starts with \"https://archive.org/details/\"")
+		if url.startswith("https://archive.org/details/"):
+			book_id = list(filter(None, url.split("/")))[3]
+			books.append((book_id, url))
+		elif len(url.split("/")) == 1:
+			books.append((url, "https://archive.org/details/" + url))
+		else:
+			print(f"{url} --> Invalid book. URL must start with \"https://archive.org/details/\", or be a book id without any \"/\"")
 			exit()
 
-	print(f"{len(urls)} Book(s) to download")
+	print(f"{len(books)} Book(s) to download")
 	session = login(email, password)
 
-	for url in urls:
-		book_id = list(filter(None, url.split("/")))[3]
+	for book in books:
+		book_id = book[0]
+		url = book[1]
 		print("="*40)
 		print(f"Current book: https://archive.org/details/{book_id}")
 		session = loan(session, book_id)


### PR DESCRIPTION
If `--url XXXX` is used and `XXXX` does not contain a `/`, add the prefix `https://archive.org/details/` automatically.  Otherwise, the url is used as before and must start with the prefix.

Also affects each line in `--file books.txt`.