### PR TITLE
Update login method to new API

### DIFF
--- a/archive-org-downloader.py
+++ b/archive-org-downloader.py
@@ -136,7 +136,7 @@ def download(session, n_threads, directory, links, scale, book_id):
 			tasks.append(executor.submit(download_one_image, session=session, link=link, i=i, directory=directory, book_id=book_id, pages=pages))
 		for task in tqdm(futures.as_completed(tasks), total=len(tasks)):
 			pass
-
+	
 	images = [image_name(pages, i, directory) for i in range(len(links))]
 	return images
 
@@ -219,7 +219,7 @@ if __name__ == "__main__":
 			directory = f"{_directory}({i})"
 			i += 1
 		os.makedirs(directory)
-
+		
 		if args.meta:
 			print("Writing metadata.json...")
 			with open(f"{directory}/metadata.json",'w') as f:

--- a/archive-org-downloader.py
+++ b/archive-org-downloader.py
@@ -24,7 +24,7 @@ def get_book_infos(session, url):
 	data = response.json()['data']
 	title = data['brOptions']['bookTitle'].strip().replace(" ", "_")
 	title = ''.join( c for c in title if c not in '<>:"/\\|?*' ) # Filter forbidden chars in directory names (Windows & Linux)
-	title = title[:150] # Trim the title to avoid long file names
+	title = title[:150] # Trim the title to avoid long file names	
 	metadata = data['metadata']
 	links = []
 	for item in data['brOptions']['data']:


### PR DESCRIPTION
It appears archive.org has changed their login API, and now requires requests to have `Content-Type: application/x-www-form-urlencoded`.