### PR TITLE
Fix OSError on Windows with Python 3.13 when converting datetime to PDF metadata

### DIFF
--- a/archive-org-downloader.py
+++ b/archive-org-downloader.py
@@ -3,7 +3,7 @@ import random, string
 from concurrent import futures
 from tqdm import tqdm
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 import argparse
 import os
 import sys
@@ -320,7 +320,7 @@ if __name__ == "__main__":
 			# date
 			if 'date' in metadata:
 				try:
-					pdfmeta['creationdate'] = datetime.strptime(metadata['date'][0:4], '%Y')
+					pdfmeta['creationdate'] = datetime.strptime(metadata['date'][0:4], '%Y').replace(tzinfo=timezone.utc)
 				except:
 					pass
 			# keywords


### PR DESCRIPTION
- Import timezone from the datetime module
- Make a datetime object timezone-aware by adding UTC timezone info
- Fixes 'OSError: [Errno 22] Invalid argument' when img2pdf tries to convert naive datetime to UTC
- Issue occured specifically on Windows with Python 3.13 for dates parsed from metadata